### PR TITLE
Hardcodes newsroom site

### DIFF
--- a/dev.simonbs.apple.newsroom/plugin-config.json
+++ b/dev.simonbs.apple.newsroom/plugin-config.json
@@ -3,6 +3,7 @@
   "display_name": "Apple Newsroom",
   "default_color": "gray",
   "icon": "https://github.com/simonbs/tapestry-plugins/blob/main/dev.simonbs.apple.newsroom/icon.png?raw=true",
+  "site": "https://apple.com/newsroom/rss-feed.rss",
   "provides_attachments": true,
   "check_interval": 300
 }


### PR DESCRIPTION
Hej Simon!

I was checking out your tapestry connectors, and found that the newsroom one prompted me for a "Site" which didn't make sense since to me since the connector advertises which site it's going to connect to: Apple Newsroom.

Thanks to your code being available on GH, I had an opportunity to dig into why that was.

I submit for your consideration: A small change so people won't be prompted to select the site in the future 🙂